### PR TITLE
Rename the deployment job

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -8,7 +8,7 @@ on:
             - 'master'
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Description
Rename the deployment job to be called "deploy" instead of "build".