### PR TITLE
Use the proper name in the generated artifact during deployment

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -44,7 +44,7 @@ jobs:
         git_tag_prefix: "v"
 
     - name: Changelog
-      uses: scottbrenner/generate-changelog-action@master
+      uses: Bullrich/generate-release-changelog@master
       id: Changelog
       env:
         REPO: ${{ github.repository }}

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -80,7 +80,7 @@ jobs:
         path: coverage
 
     - name: Package artifact
-      run: zip -r gatsby-plugin-klaro-v${{ env.PACKAGE_VERSION }}.zip .
+      run: zip -r gatsby-plugin-tagmanager-v${{ env.PACKAGE_VERSION }}.zip .
 
     - name: Upload artifact
       id: upload-release-asset


### PR DESCRIPTION
## Description
Use the proper name in the generated artifact during deployment
Also changed the changelog generator to a tag/release based one to get it to work properly.